### PR TITLE
Update simple websocket server

### DIFF
--- a/wspubctrl/detail/client_impl.cpp
+++ b/wspubctrl/detail/client_impl.cpp
@@ -29,7 +29,7 @@ namespace wspubctrl {
         _cnd.notify_one();
       };
 
-      _client.on_message = [this](ConnectionPtr connection, MessagePtr message) {
+      _client.on_message = [this](ConnectionPtr connection, InMessagePtr message) {
         unique_lock<mutex> lock(_mtx);
         _payload = message->string();
         _state = State::connected;
@@ -107,9 +107,7 @@ namespace wspubctrl {
         throw runtime_error("timeout: could not establish connection for request");
       }
 
-      auto send_stream = make_shared<SendStream>();
-      *send_stream << payload;
-      _connection->send(send_stream);
+      _connection->send(payload);
 
       if (timeout_ms == forever) {
         _cnd.wait(lock);

--- a/wspubctrl/detail/client_impl.hpp
+++ b/wspubctrl/detail/client_impl.hpp
@@ -12,8 +12,7 @@ namespace wspubctrl {
     using WsClient = SimpleWeb::SocketClient<SimpleWeb::WS>;
     typedef WsClient::Connection Connection;
     typedef std::shared_ptr<WsClient::Connection> ConnectionPtr;
-    typedef std::shared_ptr<WsClient::Message> MessagePtr;
-    typedef WsClient::SendStream SendStream;
+    typedef std::shared_ptr<WsClient::InMessage> InMessagePtr;
 
 
     class ClientImpl{


### PR DESCRIPTION
- Update submodule remote
- Update to send payload directly, no need for SendStream
- Update `Message` to `InMessage` per upstream rename.
- Update example
- Fix test jig
