### PR TITLE
Ensure that the thread is joinable before joining to it.

### DIFF
--- a/wspubctrl/server.cpp
+++ b/wspubctrl/server.cpp
@@ -77,7 +77,9 @@ namespace wspubctrl {
 
     void stop_thread() {
       _server.stop();
-      _thread.join();
+      if (_thread.joinable()) {
+        _thread.join();
+      }
     }
 
     WsServer _server;


### PR DESCRIPTION
Ensure that the thread is joinable before joining to it. Otherwise it raises a system_error exception if the initialization fails somewhere.